### PR TITLE
fix: resolve mobile horizontal overflow in About and Services sections

### DIFF
--- a/src/components/AboutSection.js
+++ b/src/components/AboutSection.js
@@ -78,7 +78,7 @@ const AboutSection = ({ darkMode }) => {
       }}
       transition={{ duration: 0.5 }}
     >
-      <div className="max-w-[1400px] mx-auto px-4 sm:px-8 md:px-16 lg:px-24">
+      <div className="max-w-[1400px] mx-auto px-4 sm:px-6 md:px-16 lg:px-24 overflow-hidden">
         
         
         <div className="flex flex-col lg:flex-row items-start gap-6 md:gap-12 lg:gap-6">

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -105,7 +105,7 @@ const Layout = ({ children }) => {
             </div>
 
             {/* Mobile Menu Button */}
-            <div className="md:hidden pr-2">
+            <div className="md:hidden">
               <button
                 onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
                 className="p-2 rounded-full bg-black/30 border border-white/10 shadow-lg shadow-black/20 backdrop-blur-md transition-all hover:bg-white/10"

--- a/src/components/ServicesSection.js
+++ b/src/components/ServicesSection.js
@@ -48,7 +48,7 @@ const ServicesSection = ({ darkMode }) => {
     <motion.section
       ref={ref}
       id="services"
-      className="relative min-h-screen flex items-center justify-center py-12 md:py-24 bg-black"
+      className="relative min-h-screen flex items-center justify-center py-12 md:py-24 bg-black overflow-hidden"
       initial="hidden"
       animate={controls}
       variants={{
@@ -77,7 +77,7 @@ const ServicesSection = ({ darkMode }) => {
       </motion.div>
       {/* Mobile section label - positioned at top */}
       <motion.div 
-        className="absolute top-0 right-5 transform -translate-x-1/2 lg:hidden z-10"
+        className="absolute top-0 right-2 lg:hidden z-10"
         variants={{
           hidden: { opacity: 0, y: -20 },
           visible: { opacity: 1, y: 0 }
@@ -85,17 +85,17 @@ const ServicesSection = ({ darkMode }) => {
         transition={{ duration: 0.5, delay: 0.2 }}
       >
         <motion.div
-          className="bg-gray-900 px-6 py-3 rounded-b-lg"
+          className="bg-gray-900 px-3 sm:px-4 py-2 sm:py-3 rounded-b-lg"
           style={{ borderRadius: '0 0 0.5rem 0.5rem' }}
           whileHover={{ scale: 1.05 }}
           transition={{ type: "spring", stiffness: 400, damping: 10 }}
         >
-          <span className="text-white text-sm sm:text-base font-semibold tracking-widest">SERVICES</span>
+          <span className="text-white text-xs sm:text-sm font-semibold tracking-widest">SERVICES</span>
         </motion.div>
       </motion.div>
       
       {/* Main content */}
-      <div className="max-w-[1400px] mx-auto px-4 sm:px-8 md:px-16 lg:px-24 relative z-20">
+      <div className="max-w-[1400px] mx-auto px-4 sm:px-6 md:px-16 lg:px-24 relative z-20 overflow-hidden">
         
         <div className="flex flex-col lg:flex-row items-start gap-8 md:gap-12 lg:gap-16">
           {/* Left: Services List */}


### PR DESCRIPTION
- Reduce container padding on mobile devices (sm:px-8 → sm:px-6)
- Add overflow-hidden to prevent content extending beyond viewport
- Fix ServicesSection mobile label positioning and sizing
- Remove problematic transform positioning that caused overflow
- Optimize mobile responsiveness across components

Fixes horizontal scrolling issues on mobile devices while maintaining desktop layout integrity.